### PR TITLE
[WIP] feat(auth): add exec based auth provider

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/cache.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/cache.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// alias so tests can use stub for deterministic results
+var timeNow = time.Now
+
+// Token groups the token string and expiration for caching
+type Token struct {
+	Token     string
+	ExpiresOn time.Time
+}
+
+func (t *Token) isExpired() bool {
+	return timeNow().After(t.ExpiresOn)
+}
+
+// TokenSource should be implemented by auth providers
+type TokenSource interface {
+	Token() (*Token, error)
+}
+
+// TokenStore is a simple token cache to use with whichever auth provider
+type TokenStore struct {
+	lock   sync.Mutex
+	token  *Token
+	source TokenSource
+}
+
+func newTokenStore(source TokenSource) *TokenStore {
+	return &TokenStore{source: source}
+}
+
+// Token returns a token from source, cached and refetched when expired
+func (t *TokenStore) Token() (string, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// check for cached token
+	if t.token != nil && !t.token.isExpired() {
+		return t.token.Token, nil
+	}
+	// fetch a new token
+	token, err := t.source.Token()
+	if err != nil {
+		return "", fmt.Errorf("could not fetch new token: %v", err)
+	}
+	if token == nil {
+		return "", errors.New("nil token returned by source")
+	}
+	// update cache
+	t.token = token
+	return token.Token, nil
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/cache_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/cache_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+type mockTokenSource struct {
+	t   *Token
+	err error
+}
+
+func (m mockTokenSource) Token() (*Token, error) {
+	return m.t, m.err
+}
+
+func TestTokenCache(t *testing.T) {
+	const (
+		unexpiredTokenString = "mock-unexpired-token-string"
+		expiredTokenString   = "mock-expired-token-string"
+	)
+	var (
+		onceWasNow       = time.Date(2018, time.January, 19, 22, 0, 0, 0, time.UTC)
+		onceWasTheFuture = time.Date(2018, time.January, 19, 23, 30, 0, 0, time.UTC)
+		stillIsThePast   = time.Date(2018, time.January, 19, 21, 30, 0, 0, time.UTC)
+		unexpiredToken   = &Token{
+			Token:     unexpiredTokenString,
+			ExpiresOn: onceWasTheFuture,
+		}
+		expiredToken = &Token{
+			Token:     expiredTokenString,
+			ExpiresOn: stillIsThePast,
+		}
+	)
+	timeNow = func() time.Time { return onceWasNow }
+
+	tests := []struct {
+		description string
+
+		cachedToken  *Token
+		storedToken  *Token
+		storageError error
+
+		expectedTokenString string
+		expectedError       error
+	}{
+		{
+			description: "returns cached token when not expired",
+			cachedToken: unexpiredToken,
+			storedToken: expiredToken,
+
+			expectedTokenString: unexpiredTokenString,
+		},
+		{
+			description: "returns new token from storage when expired",
+			cachedToken: expiredToken,
+			storedToken: unexpiredToken,
+
+			expectedTokenString: unexpiredTokenString,
+		},
+		{
+			description:  "returns errors fetching new token from storage",
+			cachedToken:  expiredToken,
+			storageError: errors.New("token store error"),
+
+			expectedError: errors.New("could not fetch new token: token store error"),
+		},
+		{
+			description: "returns error when storage returns no token",
+			cachedToken: expiredToken,
+			storedToken: nil,
+
+			expectedError: errors.New("nil token returned by source"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			store := &TokenStore{
+				token:  tt.cachedToken,
+				source: mockTokenSource{tt.storedToken, tt.storageError},
+			}
+			actualTokenStr, err := store.Token()
+			if tt.expectedError != nil {
+				if err == nil {
+					t.Errorf("missing expected error: expected=%v", tt.expectedError)
+				}
+				if tt.expectedError.Error() != err.Error() {
+					t.Errorf("unexpected error: expected=%v actual=%v", tt.expectedError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if actualTokenStr != tt.expectedTokenString {
+				t.Errorf("got unexpected token from cache: expected='%s' actual='%s'",
+					tt.expectedTokenString, actualTokenStr)
+			}
+			refetchedTokenString, err := store.Token()
+			if refetchedTokenString != tt.expectedTokenString {
+				t.Errorf("unexpected token refetching token: expected='%s' actual='%s'",
+					tt.expectedTokenString, refetchedTokenString)
+			}
+		})
+	}
+
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/external/external.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/external/external.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/util/net"
+	restclient "k8s.io/client-go/rest"
+)
+
+func init() {
+	if err := resetclient.RegisterAuthProviderPlugin("external", newExternalAuthProvider); err != nil {
+		glog.Fatalf("Failed to register external auth provider plugin: %v", err)
+	}
+}
+
+func newExternalAuthProvider(_ string, cfg map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+	return nil, errors.New("not implemented")
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/external/external.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/external/external.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -33,5 +34,54 @@ func init() {
 }
 
 func newExternalAuthProvider(_ string, cfg map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
-	return nil, errors.New("not implemented")
+	return &externalAuthProvider{}, nil
 }
+
+type externalAuthProvider struct {
+	tokenSource auth.TokenSource
+}
+
+var _ restclient.AuthProvider = &externalAuthProvider{}
+
+func (e *externalAuthProvider) WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	return &externalAuthRoundTripper{
+		tokenSource:  e.tokenSource,
+		roundTripper: rt,
+	}
+}
+func (e *externalAuthProvider) Login() error {
+	return errors.New("not implemented")
+}
+
+type externalAuthRoundTripper struct {
+	tokenSource  auth.TokenSource
+	roundTripper http.RoundTripper
+}
+
+var _ net.RoundTripperWrapper = &externalAuthRoundTripper{}
+
+func (r *externalAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return r.roundTripper.RoundTrip(req)
+	}
+
+	token, err := r.tokenSource.Token()
+	if err != nil {
+		glog.Errorf("Failed to acquire a token: %v", err)
+		return nil, fmt.Errorf("acquiring a token for authorization header: %v", err)
+	}
+
+	// clone Header to avoid modifying on original request, as per RoundTripper contract
+	req2 := new(http.Request)
+	*req2 = *req
+	req2.Header = make(http.Header, len(req.Header))
+	for k, s := range req.Header {
+		req2.Header[k] = append([]string(nil), s...) // copy slice
+	}
+
+	req2.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+
+	return r.roundTripper.RoundTrip(req2)
+}
+
+func (r *externalAuthRoundTripper) WrappedRoundTripper() http.RoundTripper { return r.roundTripper }

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -74,6 +74,9 @@ type Config struct {
 	// Impersonate is the configuration that RESTClient will use for impersonation.
 	Impersonate ImpersonationConfig
 
+	// ExternalTokener is configuration for calling out to an executable to fetch auth tokens
+	ExternalTokener *clientcmdapi.ExecConfig
+
 	// Server requires plugin-specified authentication.
 	AuthProvider *clientcmdapi.AuthProviderConfig
 
@@ -435,6 +438,7 @@ func CopyConfig(config *Config) *Config {
 			Extra:    config.Impersonate.Extra,
 			UserName: config.Impersonate.UserName,
 		},
+		ExternalTokener:     config.ExternalTokener,
 		AuthProvider:        config.AuthProvider,
 		AuthConfigPersister: config.AuthConfigPersister,
 		TLSClientConfig: TLSClientConfig{

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -269,6 +269,7 @@ func TestAnonymousConfig(t *testing.T) {
 		expected.Password = ""
 		expected.AuthProvider = nil
 		expected.AuthConfigPersister = nil
+		expected.ExternalTokener = nil
 		expected.TLSClientConfig.CertData = nil
 		expected.TLSClientConfig.CertFile = ""
 		expected.TLSClientConfig.KeyData = nil

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -101,6 +101,9 @@ type AuthInfo struct {
 	// TokenFile is a pointer to a file that contains a bearer token (as described above).  If both Token and TokenFile are present, Token takes precedence.
 	// +optional
 	TokenFile string `json:"tokenFile,omitempty"`
+	// ExternalTokener contains information for an executable that will output a bearer token (as described above).  If Token or TokenFile are present, Token, if present, otherwise TokenFile takes precedence.
+	// +optional
+	ExternalTokener *ExecConfig `json:"tokenExec,omitempty"`
 	// Impersonate is the username to act-as.
 	// +optional
 	Impersonate string `json:"act-as,omitempty"`
@@ -138,6 +141,26 @@ type Context struct {
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions map[string]runtime.Object `json:"extensions,omitempty"`
+}
+
+// ExecConfig contains information for constructing an executable to run via os.Exec
+type ExecConfig struct {
+	// Command is the name of the command to be executed
+	Command string `json:"command"`
+	// Args lists arguments to supply to the command
+	// +optional
+	Args []string `json:"args"`
+	// Env defines additional environment variables to expose to the process. These
+	// are unioned with the host's environment, with variable values lists here having
+	// precedence.
+	// +optional
+	Env []ExecEnvVar `json:"env"`
+}
+
+// ExecEnvVar describes an environment variable to set in an executable's environment
+type ExecEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // AuthProviderConfig holds the configuration for a specified auth provider.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -241,7 +241,9 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 		mergedConfig.AuthProvider = configAuthInfo.AuthProvider
 		mergedConfig.AuthConfigPersister = persistAuthConfig
 	}
-
+	if configAuthInfo.ExternalTokener != nil {
+		mergedConfig.ExternalTokener = configAuthInfo.ExternalTokener
+	}
 	// if there still isn't enough information to authenticate the user, try prompting
 	if !canIdentifyUser(*mergedConfig) && (fallbackReader != nil) {
 		if len(config.promptedCredentials.username) > 0 && len(config.promptedCredentials.password) > 0 {
@@ -289,8 +291,8 @@ func makeServerIdentificationConfig(info clientauth.Info) restclient.Config {
 
 func canIdentifyUser(config restclient.Config) bool {
 	return len(config.Username) > 0 ||
-		(len(config.CertFile) > 0 || len(config.CertData) > 0) ||
-		len(config.BearerToken) > 0 ||
+		len(config.CertFile) > 0 || len(config.CertData) > 0 ||
+		len(config.BearerToken) > 0 || config.ExternalTokener != nil ||
 		config.AuthProvider != nil
 }
 


### PR DESCRIPTION
### 🚧 Work in Progress
These changes are not in a completed state. All code and commits are subject to change. No guarantees are made about the state of the code. At any given time, the code may not work or even compile.

#### ⚠️ *PR for personal use only*
This PR is not intended to be the same changes for an upstream pull request. PR is for personal editing, commenting, and viewing only.

## Description
Support exec-based authentication plugins as a first-class feature for clients (client-go consumers and `kubectl`). Add ability for client-go to fetch credentials by executing a command and reading
that command's stdout.

### Upstream Proposal 
###### Proposal - [kubernetes/community#1503](https://github.com/kubernetes/community/pull/1503/files) 
> proposal: external kubectl auth providers

..
#### Additional Reference
###### Issue and Discussion - [kubernetes/kubernetes#35530](https://github.com/kubernetes/kubernetes/issues/35530#issuecomment-256170024)
> Feature proposal: generic cmd auth provider plugin for kubectl
